### PR TITLE
Move secret_key_base to environment variables, for all envs

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -3,3 +3,4 @@ HAYASHI_DATABASE_URL = "postgresql://localhost/hayashi_development"
 STELLARD_URL         = "http://localhost:39132"
 DISABLE_RATE_LIMIT   = true
 FRIENDBOT_SECRET     = "sfyjodTxbwLtRToZvi6yQ1KnpZriwTJ7n6nrASFR6goRviCU3Ff"
+SECRET_KEY_BASE      = "c1444052ef5183c4e6f8e4c6f18a5034902f3e9833a022cecb99005ad86a6927fa40db442e80c22b7a62186753fd7e507baf62408904465b3637101f933ad8ed"

--- a/.env.test
+++ b/.env.test
@@ -2,3 +2,4 @@ DATABASE_USER        = $USER
 DATABASE_URL         = "postgresql://localhost/horizon_test?user=$DATABASE_USER"
 HAYASHI_DATABASE_URL = "postgresql://localhost/hayashi_test?user=$DATABASE_USER"
 STELLARD_URL         = "http://localhost:39132"
+SECRET_KEY_BASE      = "edd3df3f2ad11791080fb648433a957abebbb4c4a819419516e23c165e13b36b46a8e04d4d65af5fdef2688a84fcb997950b9a0842a431fbf396b1ba0747f9f5"

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -10,11 +10,12 @@
 # Make sure the secrets in this file are kept private
 # if you're sharing your code publicly.
 
-development:
-  secret_key_base: c1444052ef5183c4e6f8e4c6f18a5034902f3e9833a022cecb99005ad86a6927fa40db442e80c22b7a62186753fd7e507baf62408904465b3637101f933ad8ed
-
-test:
-  secret_key_base: edd3df3f2ad11791080fb648433a957abebbb4c4a819419516e23c165e13b36b46a8e04d4d65af5fdef2688a84fcb997950b9a0842a431fbf396b1ba0747f9f5
-
-production:
+default: &default
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+
+development:
+  <<: *default
+test:
+  <<: *default
+production:
+  <<: *default


### PR DESCRIPTION
This PR works to make the difference between different RAILS_ENV environments smaller.  Particularly, this PR makes it such that Rails' secret_key_base is always loaded from the process environment, regardless of RAILS_ENV.