### PR TITLE
Fix throttle specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,4 +61,5 @@ group :test, :development do
   gem 'webmock', require: false
   gem 'yard'
   gem 'apiaryio'
+  gem 'timecop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,6 +234,7 @@ GEM
     thread_safe (0.3.5)
     thread_safe (0.3.5-java)
     tilt (1.4.1)
+    timecop (0.7.3)
     timers (4.0.1)
       hitimes
     torquebox-core (4.0.0.alpha1-java)
@@ -295,6 +296,7 @@ DEPENDENCIES
   sqlite3
   stellar-base
   sucker_punch
+  timecop
   torquebox-web (>= 4.0.0.alpha1)
   vcr
   webmock

--- a/spec/requests/throttling_spec.rb
+++ b/spec/requests/throttling_spec.rb
@@ -3,16 +3,27 @@ require 'rails_helper'
 RSpec.describe "Request Throttler", type: :request do
 
   it "throttles an ip address after 300 requests in a 5 minute period", :slow do    
-    300.times do |i|
+    now = Time.now
+
+    Timecop.freeze do
+      300.times do |i|
+        get "/"
+        expect(response).to have_status(:ok)
+      end
+
       get "/"
+      expect(response).to have_status(:service_unavailable)
+
+      get "/", nil, {'REMOTE_ADDR' => "10.0.0.1"} 
       expect(response).to have_status(:ok)
     end
 
-    get "/"
-    expect(response).to have_status(:service_unavailable)
-
-    get "/", nil, {'REMOTE_ADDR' => "10.0.0.1"} 
-    expect(response).to have_status(:ok)
+    # skip 5 minutes ahead, ensure that we can request again
+    
+    Timecop.freeze(5.minutes.from_now(now)) do
+      get "/"
+      expect(response).to have_status(:ok)
+    end
   end
 
   it "renders a problem response when throttling" do


### PR DESCRIPTION
This commit integrates timecop, and uses it to remove time
dependencies from the throttling spec.