### PR TITLE
Capture exception when stellard connection fails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'low_card_tables'
 gem 'rack-cors', :require => 'rack/cors'
 gem 'rails_stdout_logging'
 gem 'awesome_print'
+gem 'sentry-raven'
 
 # note: the following celluloid and sucker_punch gems are require: false
 # so that the rspec system can bootup the system manually.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,6 +203,8 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    sentry-raven (0.13.1)
+      faraday (>= 0.7.6)
     shellany (0.0.1)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
@@ -291,6 +293,7 @@ DEPENDENCIES
   rails_stdout_logging
   rspec-rails
   sdoc (~> 0.4.0)
+  sentry-raven
   shoulda-matchers
   simplecov
   sqlite3

--- a/app/services/exception_reporter.rb
+++ b/app/services/exception_reporter.rb
@@ -1,0 +1,7 @@
+class ExceptionReporter
+  CLIENT = Raven
+
+  def self.capture(exception)
+    CLIENT.capture_exception(exception)
+  end
+end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,3 @@
+Raven.configure do |config|
+  config.environments = %w{production staging}
+end

--- a/spec/models/transaction_submission_spec.rb
+++ b/spec/models/transaction_submission_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe TransactionSubmission, type: :model do
+  describe "#process" do
+    context "when connection fails" do
+      it "reports exception" do
+        stub_parsed_transaction_envelope
+        transaction_envelope = SecureRandom.hex
+        exception = Faraday::ConnectionFailed.new("error")
+        allow($stellard).to receive(:get).and_raise(exception)
+        allow(ExceptionReporter).to receive(:capture)
+        transaction_submission = TransactionSubmission.new(transaction_envelope)
+
+        transaction_submission.process
+
+        expect(ExceptionReporter).to have_received(:capture).with(exception)
+      end
+    end
+  end
+
+  def stub_parsed_transaction_envelope
+    parsed_envelope = double("parsed_envelope", tx: double(hash: "hash"))
+    allow(Stellar::TransactionEnvelope).to receive(:from_xdr).
+      and_return(parsed_envelope)
+  end
+end

--- a/spec/services/exception_reporter_spec.rb
+++ b/spec/services/exception_reporter_spec.rb
@@ -1,10 +1,10 @@
 require "rails_helper"
 
-RSpec.describe TransactionSubmission do
+RSpec.describe ExceptionReporter do
   describe ".capture" do
-    it "reports exception to Sentry" do
+    it "captures exception" do
       error = "error"
-      allow(Raven).to receive(:capture_exception)
+      allow(ExceptionReporter::CLIENT).to receive(:capture_exception)
 
       ExceptionReporter.capture(error)
 

--- a/spec/services/exception_reporter_spec.rb
+++ b/spec/services/exception_reporter_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe TransactionSubmission do
+  describe ".capture" do
+    it "reports exception to Sentry" do
+      error = "error"
+      allow(Raven).to receive(:capture_exception)
+
+      ExceptionReporter.capture(error)
+
+      expect(ExceptionReporter::CLIENT).to have_received(:capture_exception).
+        with(error)
+    end
+  end
+end


### PR DESCRIPTION
* Set up exception monitoring with Sentry
* Introduce `ExceptionReporter`
* Capture exception when connection fails in
  `TransactionSubmission.process`
* Note: Be sure to set the `SENTRY_DSN` environment variable before deploying this commit.

@nullstyle I could use some feedback on this one. My goal here is just to get Sentry set up and add exception reporting to a method where it will clearly be helpful. I have a couple specific questions:

1. Do you anticipate monitoring exceptions in production and staging environments, or just production?
2. I introduced the `ExceptionReporter` adapter object to wrap the `Raven` client for greater flexibility, but this could be a case of YAGNI.
3. I wrote my tests using the new `expect` syntax but can change to `should` if that is your preferred style.