### PR TITLE
Testing scenarios system

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,5 +63,5 @@ group :test, :development do
   gem 'yard'
   gem 'apiaryio'
   gem 'timecop'
-  gem 'stellar_core_commander', platform: :ruby, require: false
+  gem 'stellar_core_commander', ">= 0.0.2", platform: :ruby, require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,7 +232,7 @@ GEM
       activesupport (~> 4)
       rbnacl
       xdr
-    stellar_core_commander (0.0.1)
+    stellar_core_commander (0.0.2)
       activesupport (>= 4.0.0)
       contracts (~> 0.9)
       faraday (~> 0.9.1)
@@ -309,7 +309,7 @@ DEPENDENCIES
   simplecov
   sqlite3
   stellar-base
-  stellar_core_commander
+  stellar_core_commander (>= 0.0.2)
   sucker_punch
   timecop
   torquebox-web (>= 4.0.0.alpha1)

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -15,4 +15,67 @@ namespace :db do
       History::LedgerImporterJob.new.perform(header.sequence)
     end
   end
+
+
+  desc "runs testing scenarios, dumping results to tmp/secenarios"
+  task :build_scenarios => :environment do
+    Rails.application.eager_load!
+
+    raise "This should only be run from RAILS_ENV='test'" unless Rails.env.test?
+
+    scenarios = Dir["spec/fixtures/scenarios/*.rb"]
+    FileUtils.mkdir_p "tmp/scenarios"
+    require 'stellar_core_commander'
+    
+    stellar_core_path = `which stellar-core`.strip
+    raise "stellar-core is not on PATH" unless $?.success?
+
+    cmd = StellarCoreCommander::Commander.new stellar_core_path
+    cmd.cleanup_at_exit!    
+
+    scenarios.each do |path|
+      scenario_name = File.basename(path, ".rb")
+      process    = cmd.make_process
+      transactor = StellarCoreCommander::Transactor.new(process)
+
+      process.run
+      process.wait_for_ready
+
+      transactor.run_recipe path
+      transactor.close_ledger
+
+      # dump the stellar-core data
+      IO.write("tmp/scenarios/#{scenario_name}-core.sql", process.dump_database)
+
+      # clear horizon
+      History::Base.transaction{ History::Base.descendants.each(&:delete_all) }
+
+      # reimport history
+      Hayashi::Base.clear_all_connections!
+      database_url = "postgres://localhost/#{process.database_name}"
+      Hayashi::Base.establish_connection database_url
+
+      Hayashi::LedgerHeader.order("ledgerseq ASC").all.each do |header|
+        History::LedgerImporterJob.new.perform(header.sequence)
+      end
+
+      # dump horizon db
+      d = PgDump.new(History::Base, "tmp/scenarios/#{scenario_name}-horizon.sql")
+      d.dump
+
+      Hayashi::Base.clear_all_connections!
+    end
+
+
+    # TODO:
+    # check the scenario file
+    # clear history database
+    # launch stellar-core in manual crank mode
+    # play scenario, confirm results as expected
+    # shutdown stellar-core
+    # trigger history rebuild
+    # dump stellar-core db
+    # dump horizon db
+
+  end
 end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -66,16 +66,5 @@ namespace :db do
       Hayashi::Base.clear_all_connections!
     end
 
-
-    # TODO:
-    # check the scenario file
-    # clear history database
-    # launch stellar-core in manual crank mode
-    # play scenario, confirm results as expected
-    # shutdown stellar-core
-    # trigger history rebuild
-    # dump stellar-core db
-    # dump horizon db
-
   end
 end

--- a/spec/fixtures/scenarios/non_native_payment.rb
+++ b/spec/fixtures/scenarios/non_native_payment.rb
@@ -1,0 +1,20 @@
+account :usd_gateway, FactoryGirl.create(:usd_gateway_key_pair)
+account :scott,  FactoryGirl.create(:scott_key_pair)
+account :andrew, FactoryGirl.create(:andrew_key_pair)
+
+payment :master, :usd_gateway,  [:native, 1000_000000]
+payment :master, :scott,        [:native, 1000_000000]
+payment :master, :andrew,       [:native, 1000_000000]
+
+close_ledger
+
+trust :scott,  :usd_gateway, "USD"
+trust :andrew, :usd_gateway, "USD"
+
+close_ledger
+
+payment :usd_gateway, :scott,  ["USD", :usd_gateway, 1000_000000]
+
+close_ledger
+
+payment :scott, :andrew, ["USD", :usd_gateway, 500_000000]

--- a/spec/support/recorder/transaction_seeder.rb
+++ b/spec/support/recorder/transaction_seeder.rb
@@ -28,6 +28,9 @@ module Recorder
           # dump results
           IO.write(@output_path, process.dump_database)
 
+          # cleanup tmpdir/db/etc.
+          process.cleanup
+
         ensure
           WebMock.disable_net_connect!
         end


### PR DESCRIPTION
This PR integrates `stellar_core_commander` into the testing system, as well as leveraging it to produce test data for go-horizon.

Notably, this PR adds the rake task `db:build_scenarios` which will produce a set of sql files in `tmp/scenarios` suitable for use in the go-horizon test suite.