### PR TITLE
Upgrade sucker_punch

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,7 +236,7 @@ GEM
       sequel (~> 4.21.0)
       slop (~> 3.6.0)
       stellar-base (= 0.0.9)
-    sucker_punch (1.4.0)
+    sucker_punch (1.5.0)
       celluloid (~> 0.16.0)
     thor (0.19.1)
     thread_safe (0.3.5)

--- a/config/initializers/friendbot.rb
+++ b/config/initializers/friendbot.rb
@@ -1,8 +1,4 @@
-class FriendbotRailtie < ::Rails::Railtie
-  config.to_prepare do
-    Friendbot.boot
-  end
-end
+Friendbot.boot
 
 unless Rails.configuration.cache_classes
   ActionDispatch::Reloader.to_cleanup do


### PR DESCRIPTION
* `sucker_punch` removes only SuckerPunch actors from the Celluloid
  registry on application boot as of 1.5.0. Release notes are here:
  https://github.com/brandonhilkert/sucker_punch/blob/master/CHANGES.md#150.
  Now that `sucker_punch` is more discriminating when clearing the
  registry we don't need to register the `Friendbot` actor in a railtie.
* This commit removes the railtie from
  `config/initializeres/friendbot.rb` and upgrades `sucker_punch` to
  1.5.0.